### PR TITLE
RI-11: верстка страницы лидерборда с моковыми данными

### DIFF
--- a/packages/client/src/components/LeaderboardElement/LeaderboardElement.module.scss
+++ b/packages/client/src/components/LeaderboardElement/LeaderboardElement.module.scss
@@ -1,0 +1,13 @@
+.leaderboardElement {
+  display: flex;
+  width: 60vh;
+  justify-content: space-around;
+  border-bottom: 1px solid #F9D838;
+  border-radius: 8px;
+  padding: 8px;
+  margin-bottom: 2vh;
+  &:hover {
+    box-shadow: 0px 0px 2px 4px rgba(249, 216, 56, 1);
+    transition: 0.2s;
+  }
+}

--- a/packages/client/src/components/LeaderboardElement/LeaderboardElement.module.scss
+++ b/packages/client/src/components/LeaderboardElement/LeaderboardElement.module.scss
@@ -1,6 +1,6 @@
 .leaderboardElement {
   display: flex;
-  width: 60vh;
+  width: 60vw;
   justify-content: space-around;
   border-bottom: 1px solid #F9D838;
   border-radius: 8px;

--- a/packages/client/src/components/LeaderboardElement/LeaderboardElement.tsx
+++ b/packages/client/src/components/LeaderboardElement/LeaderboardElement.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import styles from './LeaderboardElement.module.scss'
+
+interface LeaderboardElementProps {
+  userName: string
+  userScore: number
+}
+
+export const LeaderboardElement: React.FC<LeaderboardElementProps> = ({
+  userName,
+  userScore,
+}) => {
+  return (
+    <div className={styles.leaderboardElement}>
+      <div>{userName}</div>
+      <div>{userScore}</div>
+    </div>
+  )
+}

--- a/packages/client/src/components/LeaderboardElement/index.ts
+++ b/packages/client/src/components/LeaderboardElement/index.ts
@@ -1,0 +1,1 @@
+export { LeaderboardElement } from './LeaderboardElement'

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -15,6 +15,7 @@ import { ChangeData } from '@/pages/ProfilePages/ChangeData'
 import { ChangePassword } from '@/pages/ProfilePages/ChangePassword'
 
 import { store } from './store/store'
+import { Leaderboard } from '@/pages/Leaderboard'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <Provider store={store}>
@@ -39,10 +40,10 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
           }
         />
         <Route path="/game/final-page" element={<FinalPage />} />
-        <Route path="/some-page" element={<div>some page</div>} />
-         <Route path="/profile" element={<Profile />} />
+        <Route path="/profile" element={<Profile />} />
         <Route path="/profile/editData" element={<ChangeData />} />
         <Route path="/profile/editPassword" element={<ChangePassword />} />
+        <Route path="/leaderboard" element={<Leaderboard />} />
       </Routes>
     </BrowserRouter>
   </Provider>

--- a/packages/client/src/pages/Leaderboard/Leaderboard.module.scss
+++ b/packages/client/src/pages/Leaderboard/Leaderboard.module.scss
@@ -1,0 +1,25 @@
+@use '../../styles/variables' as variables;
+
+.leaderboard {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  align-items: center;
+  font-family: variables.$font-body;
+  color: variables.$font-color;
+  background-color: variables.$background-color;
+  &__title {
+    font-size: 32px;
+    margin-top: 8vh;
+    margin-bottom: 4vh;
+  }
+  &__header {
+    display: flex;
+    width: 60vh;
+    justify-content: space-around;
+    border: 1px solid #F9D838;
+    border-radius: 8px;
+    padding: 8px;
+    margin-bottom: 2vh;
+  }
+}

--- a/packages/client/src/pages/Leaderboard/Leaderboard.module.scss
+++ b/packages/client/src/pages/Leaderboard/Leaderboard.module.scss
@@ -15,7 +15,7 @@
   }
   &__header {
     display: flex;
-    width: 60vh;
+    width: 60vw;
     justify-content: space-around;
     border: 1px solid #F9D838;
     border-radius: 8px;

--- a/packages/client/src/pages/Leaderboard/Leaderboard.tsx
+++ b/packages/client/src/pages/Leaderboard/Leaderboard.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import styles from './Leaderboard.module.scss'
+import { LeaderboardElement } from '@/components/LeaderboardElement'
+
+export const Leaderboard: React.FC = () => {
+  const mockData = [
+    { id: 1, userName: 'User 1', userScore: 111 },
+    { id: 2, userName: 'User 2', userScore: 222 },
+    { id: 3, userName: 'User 3', userScore: 333 },
+  ]
+  return (
+    <div className={styles.leaderboard}>
+      <div className={styles.leaderboard__title}>Leaderboard</div>
+      <div className={styles.leaderboard__header}>
+        <div>Name</div>
+        <div>Score</div>
+      </div>
+      {mockData.map(user => (
+        <LeaderboardElement
+          key={user.id}
+          userName={user.userName}
+          userScore={user.userScore}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/client/src/pages/Leaderboard/index.ts
+++ b/packages/client/src/pages/Leaderboard/index.ts
@@ -1,0 +1,1 @@
+export { Leaderboard } from './Leaderboard'


### PR DESCRIPTION
### Какую задачу решаем
Сверстать страницу лидерборда

Добавить роут для лидерборда.
Сверстать страницу лидерборда.
Добавлен роут для лидерборда, при переходе авторизованного пользователя на этот экран отображается список моковых рекордов.

Лидерборд представляет собой список рекордов пользователей вашей игры.

### Скриншоты/видяшка (если есть)
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/388fbeae-5bb3-4498-b5fa-4b64aa6fa35f" />

### TBD (если есть)